### PR TITLE
Add the title of the service

### DIFF
--- a/src/main/resources/cloud/apipage/apipage-main.xsl
+++ b/src/main/resources/cloud/apipage/apipage-main.xsl
@@ -676,6 +676,7 @@
           />
         </div>
         <div class="col-md-5">
+          <strong><xsl:value-of select="wadl:doc/@title"/></strong>
           <xsl:choose>
             <xsl:when
               test="wadl:doc//d:*[@role = 'shortdesc'] or wadl:doc//xhtml:*[@class = 'shortdesc']">


### PR DESCRIPTION
(Originally submitted to rackerlabs/clouddocs-maven-plugin as https://github.com/rackerlabs/clouddocs-maven-plugin/pull/129)
## Overview

Documentation is showing service descriptions, but is missing the title from the WADL.
### Before

![screen shot 2014-07-17 at 11 02 35 am](https://cloud.githubusercontent.com/assets/896878/3614865/88bb5e42-0dc3-11e4-90f9-5d2973608f90.png)
### After

![screen shot 2014-07-17 at 11 03 22 am](https://cloud.githubusercontent.com/assets/896878/3614867/8d7974fa-0dc3-11e4-9931-6fec8666afa4.png)
## Justification

There are few reasons I'd like to see the title in the documentation:
1. The titles are easier to remember and are used to navigate the current documentation. So I would direct someone to the "Update load balancer properties" API operation, which they'd find in the current documentation but not on api.rackspace.com.
2. It increases searchability. On docs.rackspace.com searching for "Update load balancer properties" or "Updates the properties for a specified load balancer" will get a hit, while only the latter works on api.rackspace.com.
3. I want to use product name + API operation title as the canonical name of an API so we can more clearly make comparisons across services, like "documented operations not yet implemented by fog", "operations supported by pyrax but not libcloud", or "operations supported by both mimic and pitchfork"). Right now we're using different names in different lists of operations (e.g. "Cloud Servers" vs "Nova", "Create Server" vs "Creates a server") so you can't just compare two lists without converting names.
